### PR TITLE
회원 가입, 로그인 구현 및 팀 투표, 결과 페이지 완성 & 헤더에 팀, 이름 반영

### DIFF
--- a/src/app/(CommonLayout)/vote/fe/page.tsx
+++ b/src/app/(CommonLayout)/vote/fe/page.tsx
@@ -75,7 +75,7 @@ export default function Page() {
         );
         if (response.ok) {
           const data = await response.json();
-          console.log(data);
+
           //data.result 필드를 통해 접근해야함
           setIsVoted(data.isVoted);
           setPart(data.status);

--- a/src/app/(CommonLayout)/vote/team-result/page.tsx
+++ b/src/app/(CommonLayout)/vote/team-result/page.tsx
@@ -10,14 +10,6 @@ interface teamProp {
   voteCount: number;
 }
 
-const DUMMYTEAMRANKING: teamProp[] = [
-  { teamName: 'AZITO', voteCount: 10 },
-  { teamName: 'BEATBUDDY', voteCount: 9 },
-  { teamName: 'TIG', voteCount: 8 },
-  { teamName: 'BULDOG', voteCount: 7 },
-  { teamName: 'COUPLELOG', voteCount: 6 },
-];
-
 export default function TeamResultPage() {
   const [teamState, setTeamState] = useState<teamProp[]>([]);
 
@@ -27,13 +19,29 @@ export default function TeamResultPage() {
         `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/vote/team-result`
       );
 
-      const data = await response.json();
-      console.log(data);
+      const data: teamProp[] = await response.json();
+
+      const tmpData: teamProp[] = data.sort((a, b) => {
+        if (a.voteCount === b.voteCount) {
+          // voteCount가 같을 경우, teamName으로 알파벳 순 정렬
+          return a.teamName.localeCompare(b.teamName);
+        }
+        // voteCount 내림차순 정렬
+        return b.voteCount - a.voteCount;
+      });
+
+      setTeamState(tmpData);
     }
 
     getTeamResultData();
   }, []);
+
   const router = useRouter();
+
+  // 대체 UI임 : 첫 렌더링 시에 보이지 않는 문제를 해결하기 위함임
+  if (teamState.length === 0) {
+    return null;
+  }
   return (
     <div className="flex flex-col w-full h-full relative px-5 pt-[120px] items-center">
       <Header />
@@ -47,11 +55,11 @@ export default function TeamResultPage() {
         <div className="absolute top-[-24px] left-[-18px]">
           <CrownSVG />
         </div>
-        {DUMMYTEAMRANKING[0].teamName}
+        {teamState[0].teamName}
       </div>
-      <div className="my-[10px]">{DUMMYTEAMRANKING[0].voteCount}표</div>
+      <div className="my-[10px]">{teamState[0].voteCount}표</div>
       <section className="w-full bg-white rounded-t-xl overflow-y-scroll">
-        {DUMMYTEAMRANKING.slice(1).map((team, idx) => {
+        {teamState.slice(1).map((team, idx) => {
           return (
             <div
               key={team.teamName}

--- a/src/app/(CommonLayout)/vote/team/page.tsx
+++ b/src/app/(CommonLayout)/vote/team/page.tsx
@@ -64,6 +64,8 @@ export default function TeamPage() {
 
     if (localStorageToken !== null) {
       getTeamData();
+    } else {
+      return;
     }
   }, []);
   const router = useRouter();
@@ -87,11 +89,17 @@ export default function TeamPage() {
               idx === votedIdx ? 'border-2 border-themeColor' : ''
             }`}
             onClick={() => {
-              if (TeamName[idx] === team) {
-                alert('본인이 속한 팀에는 투표할 수 없습니다!');
+              if (isVoted === 1) {
+                alert('이미 투표를 진행하셨습니다!');
                 return;
+              } else if (team === null) {
+                alert('로그인하지 않은 사용자는 투표할 수 없습니다!');
+                return;
+              } else if (TeamName[idx] === team) {
+                alert('본인이 속한 팀에는 투표할 수 없습니다!');
+              } else {
+                setVotedIdx(idx);
               }
-              setVotedIdx(idx);
             }}
           >
             {name}
@@ -107,19 +115,26 @@ export default function TeamPage() {
       >
         결과보기 ▶︎
       </div>
-      <button
-        onClick={handleSubmitTeamVote}
-        className={`bg-themeColor text-white w-full h-[70px] rounded-[10px] mt-[20px] mb-[40px] text-[28px] font-semibold ${
-          isVoted || TeamName[votedIdx] === team || votedIdx === -1
-            ? 'opacity-50 cursor-not-allowed'
-            : ''
-        }`}
-        disabled={
-          isVoted === 1 || TeamName[votedIdx] === team || votedIdx === -1
-        }
-      >
-        투표하기
-      </button>
+
+      {isVoted === 1 ? (
+        <button
+          className={`bg-themeColor text-white w-full h-[70px] rounded-[10px] mt-[20px] mb-[40px] text-[28px] font-semibold opacity-50 cursor-not-allowed`}
+        >
+          투표 완료
+        </button>
+      ) : (
+        <button
+          onClick={handleSubmitTeamVote}
+          className={`bg-themeColor text-white w-full h-[70px] rounded-[10px] mt-[20px] mb-[40px] text-[28px] font-semibold ${
+            isVoted || TeamName[votedIdx] === team || votedIdx === -1
+              ? 'opacity-50 cursor-not-allowed'
+              : ''
+          }`}
+          disabled={TeamName[votedIdx] === team || votedIdx === -1}
+        >
+          투표하기
+        </button>
+      )}
     </div>
   );
 }

--- a/src/app/(CommonLayout)/vote/team/page.tsx
+++ b/src/app/(CommonLayout)/vote/team/page.tsx
@@ -43,7 +43,14 @@ export default function TeamPage() {
   useEffect(() => {
     async function getTeamData() {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/vote/team`
+        `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/vote/team`,
+        {
+          method: 'POST',
+          headers: {
+            // Authorization: `Bearer ${token}`,
+          },
+          credentials: 'include',
+        }
       );
 
       const data = await response.json();

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 export async function POST(req: NextRequest) {
   const { loginId, password } = await req.json();
   const sendingDataObject = { loginId: loginId, password: password };
-  console.log(sendingDataObject);
+
   try {
     const tmpResponse = await fetch(
       'http://43.202.139.24:8080/api/user/login',

--- a/src/components/all/Header.tsx
+++ b/src/components/all/Header.tsx
@@ -13,8 +13,6 @@ export function Header() {
     setUsername(localStorage.getItem('username'));
   }, []);
 
-  console.log(part);
-  console.log(username);
   return (
     <header className="w-full h-[80px] bg-white flex justify-between items-center px-[20px] absolute top-0 left-0">
       <h1

--- a/src/components/all/Header.tsx
+++ b/src/components/all/Header.tsx
@@ -1,11 +1,20 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-
-const DUMMYUSER = 'FE 홍길동';
+import { useState, useEffect } from 'react';
 
 export function Header() {
+  const [part, setPart] = useState<string | null>(null);
+  const [username, setUsername] = useState<string | null>(null);
   const router = useRouter();
+
+  useEffect(() => {
+    setPart(localStorage.getItem('part'));
+    setUsername(localStorage.getItem('username'));
+  }, []);
+
+  console.log(part);
+  console.log(username);
   return (
     <header className="w-full h-[80px] bg-white flex justify-between items-center px-[20px] absolute top-0 left-0">
       <h1
@@ -17,15 +26,33 @@ export function Header() {
         CEOS
       </h1>
       <div className="flex gap-2 items-center">
-        <span className="text-[16px]">{DUMMYUSER}</span>
-        <button
-          className="bg-themeColor text-white	 text-[18px] rounded-[10px] border-none w-[80px] h-[40px]"
-          onClick={() => {
-            router.push('/login');
-          }}
-        >
-          로그인
-        </button>
+        {part && username && (
+          <span className="text-[16px]">{`${part} ${username}`}</span>
+        )}
+        {part !== null && username !== null ? (
+          <button
+            className="bg-themeColor text-white	 text-[18px] rounded-[10px] border-none w-[80px] h-[40px]"
+            onClick={() => {
+              localStorage.removeItem('jwtToken');
+              localStorage.removeItem('part');
+              localStorage.removeItem('username');
+              setPart(null);
+              setUsername(null);
+              router.push('/');
+            }}
+          >
+            로그 아웃
+          </button>
+        ) : (
+          <button
+            className="bg-themeColor text-white	 text-[18px] rounded-[10px] border-none w-[80px] h-[40px]"
+            onClick={() => {
+              router.push('/login');
+            }}
+          >
+            로그인
+          </button>
+        )}
       </div>
     </header>
   );

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -22,7 +22,6 @@ export default function LoginForm() {
         password: userPasswordValue,
       };
 
-      console.log(sendingDataObject);
       try {
         const response = await fetch(
           `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/user/login`,

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -1,9 +1,12 @@
 'use client';
 import { useRef } from 'react';
+import { useRouter } from 'next/navigation';
 
 export default function LoginForm() {
   const idRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
+
+  const router = useRouter();
 
   async function handleSubmitLoginForm(
     event: React.FormEvent<HTMLFormElement>
@@ -20,33 +23,35 @@ export default function LoginForm() {
       };
 
       console.log(sendingDataObject);
-      // try {
-      //   const response = await fetch(
-      //     `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/user/login`,
-      //     {
-      //       method: 'POST',
-      //       headers: {
-      //         'Content-Type': 'application/json',
-      //       },
-      //       body: JSON.stringify(sendingDataObject),
-      //     }
-      //   );
-
-      //   const data = await response.json();
-      // } catch (error) {
-      //   alert(error);
-      // }
       try {
-        const response = await fetch('/api/login', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(sendingDataObject),
-        });
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/user/login`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+            body: JSON.stringify(sendingDataObject),
+          }
+        );
 
-        const data = await response.json();
-        console.log(data);
+        if (!response.ok) {
+          throw new Error('Login error');
+        } else {
+          const headers = response.headers;
+
+          // 일단 타입 단언으로 오류를 뜷어주기
+          const jwtToken = headers.get('Authorization') as string;
+
+          const { part, username } = await response.json();
+
+          localStorage.setItem('jwtToken', jwtToken);
+          localStorage.setItem('part', part);
+          localStorage.setItem('username', username);
+
+          router.push('/');
+        }
       } catch (error) {
         alert(error);
       }

--- a/src/components/signup/SignupForm.tsx
+++ b/src/components/signup/SignupForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useRef } from 'react';
+import { useRouter } from 'next/navigation';
 
 export default function SignupForm() {
   const idRef = useRef<HTMLInputElement>(null);
@@ -8,6 +9,8 @@ export default function SignupForm() {
   const emailRef = useRef<HTMLInputElement>(null);
   const partRef = useRef<HTMLSelectElement>(null);
   const teamRef = useRef<HTMLSelectElement>(null);
+  const router = useRouter();
+
   async function handleSubmitSignupForm(
     event: React.FormEvent<HTMLFormElement>
   ) {
@@ -37,45 +40,46 @@ export default function SignupForm() {
         teamId: userTeamValue,
       };
 
-      console.log(sendingDataObject);
+      try {
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/user/signup`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+            body: JSON.stringify(sendingDataObject),
+          }
+        );
 
+        if (!response.ok) {
+          throw new Error('Sign up failed!');
+        } else {
+          router.push('/login');
+        }
+      } catch (error) {
+        alert(error);
+      }
       // try {
-      //   const response = await fetch(
-      //     `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/user/signup`,
-      //     {
-      //       method: 'POST',
-      //       headers: {
-      //         'Content-Type': 'application/json',
-      //       },
-      //       body: JSON.stringify(sendingDataObject),
-      //     }
-      //   );
+      //   const response = await fetch('/api/signup', {
+      //     method: 'POST',
+      //     headers: {
+      //       'Content-Type': 'application/json',
+      //     },
+      //     body: JSON.stringify(sendingDataObject),
+      //   });
 
       //   if (!response.ok) {
       //     throw new Error('Sign up failed!');
       //   }
+
+      //   const data = await response.json();
+
+      //   console.log(data);
       // } catch (error) {
       //   alert(error);
       // }
-      try {
-        const response = await fetch('/api/signup', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(sendingDataObject),
-        });
-
-        if (!response.ok) {
-          throw new Error('Sign up failed!');
-        }
-
-        const data = await response.json();
-
-        console.log(data);
-      } catch (error) {
-        alert(error);
-      }
     }
   }
 


### PR DESCRIPTION
1. 우선 cors 문제를 해결했음. 이제 더 이상 nextJS api로 프록시 호출로 해결 안하고, 그냥 브라우저 단에서 바로 `fetch`를 진행할 수가 있게 됨. 로그인을 하면 백엔드는 브라우저에게 Authorization 헤더에 jwt를 담고, body에는 usename과 part 정보를 보내줌. 우리는 이걸 javascript로 까봐야겠지? body는 그냥 `await response.json()`으로 읽어들이면 되는데, cors 정책에 의해서 헤더를 읽는 것은 안되더라고. 근데 이 부분 백엔드가 해결하는 거임. 백엔드에서 우리한테 Access-Control-Expose-Headers: Authorization 이라는 헤더를 보내줘야 우리는 javascript로 이걸 읽을 수 있게됨ㅇㅇ.
2. 이렇게 로그인 시 불러온 jwt, username, part는 로컬 스토리지에 저장하려고 이번엔. TIG 프로젝트에서는 이거 무조건 cookie에 해야됨. 왜냐? 로컬스토리지는 js로 접근 가능하니까 보안 위험 있음. 근데 지금 우리가 투표하고, 우리 투표 했는지 조회받는(`/vote/team` 같은거) api 사용하려면 post 요청 헤더에 `Authorization : Bearer 토큰명` 이렇게 하잖슴 ㅇㅇ. 즉, 백엔드가 브라우저가 자동으로 전송하는 쿠키를 열어서 jwt를 프론트엔드로부터 받는게 아니라 **Authorization** 헤더를 열어서 받은 방식으로 지금 작성해 논거임. 뭐 쿠키로 해도 되긴 하는데 그러면 백엔드 친구들이 `set-cookie` 헤더 박아주고 jwt 받는 로직 죄다 바꿔야해서 그냥 지금 방식으로 가기로 했음. 
**결론적으로**, 그냥 너 필요할 때 로컬 스토리지에서 `jwtToken`, `part`, `username` 이라는 key를 빼서 jwt, 파트명, 사용자명 가져다가 쓰면됨!

3. 우리가 팀 투표, FE 파트장 투표, BE 파트장 투표 페이지에 들어갔을 때 지금 이 사람 소속이 어디며 투표 했는지 요청 보내잖아(`/vote/team` 같은거로). 그때 돌아오는 isVoted 속성 boolean이 아니라 투표 안했으면 0, 투표 했으면 1이라 해당 타입 참고하면 좋을 거 같음. 일단 내가 하는 team 투표 관련 페이지에만 적용해놨어. 너가 fe 투표, 백엔드 투표에 반영 ㄱㄱ

일단 이 정도 인듯! 혹시 이해 안가는 부분 있으면 언제든지 연락 ㄱ ㄱ